### PR TITLE
feat: Add CLI entry point with argument parsing (Issue #1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     "langchain>=0.3.27",
 ]
 
+[project.scripts]
+diversifier = "src.cli:main"
+
 [dependency-groups]
 dev = [
     "black>=25.1.0",

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,120 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .validation import (
+    validate_python_project,
+    validate_library_name_format,
+    validate_library_exists,
+    validate_migration_feasibility
+)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="diversifier",
+        description="AI-powered tool to generate diversified project variants via dependency mutation.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  diversifier /path/to/project requests httpx
+  diversifier . pandas polars
+  diversifier ~/myproject flask fastapi
+        """,
+    )
+    
+    parser.add_argument(
+        "project_path",
+        type=str,
+        help="Path to the Python project directory to diversify"
+    )
+    
+    parser.add_argument(
+        "remove_lib",
+        type=str,
+        help="Name of the library to remove/replace"
+    )
+    
+    parser.add_argument(
+        "inject_lib",
+        type=str,
+        help="Name of the library to inject/substitute"
+    )
+    
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes"
+    )
+    
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose output"
+    )
+    
+    return parser
+
+
+def validate_project_path(path_str: str) -> Optional[Path]:
+    try:
+        path = Path(path_str).resolve()
+        
+        if not path.exists():
+            print(f"Error: Project path does not exist: {path}")
+            return None
+            
+        if not path.is_dir():
+            print(f"Error: Project path is not a directory: {path}")
+            return None
+            
+        return path
+    except Exception as e:
+        print(f"Error: Invalid project path '{path_str}': {e}")
+        return None
+
+
+def validate_library_name(lib_name: str) -> bool:
+    is_valid, message = validate_library_name_format(lib_name)
+    if not is_valid:
+        print(f"Error: {message}")
+    return is_valid
+
+
+def main() -> int:
+    parser = create_parser()
+    args = parser.parse_args()
+    
+    project_path = validate_project_path(args.project_path)
+    if not project_path:
+        return 1
+        
+    if not validate_library_name(args.remove_lib):
+        return 1
+        
+    if not validate_library_name(args.inject_lib):
+        return 1
+    
+    if args.remove_lib == args.inject_lib:
+        print("Error: remove_lib and inject_lib cannot be the same")
+        return 1
+    
+    if args.verbose:
+        print(f"Project path: {project_path}")
+        print(f"Remove library: {args.remove_lib}")
+        print(f"Inject library: {args.inject_lib}")
+        print(f"Dry run: {args.dry_run}")
+    
+    if args.dry_run:
+        print("DRY RUN: Would perform library substitution:")
+        print(f"  Project: {project_path}")
+        print(f"  Replace '{args.remove_lib}' with '{args.inject_lib}'")
+        return 0
+    
+    print("Diversifier CLI is ready - core migration logic to be implemented")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/validation.py
+++ b/src/validation.py
@@ -1,0 +1,106 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, List, Tuple
+
+
+def validate_python_project(project_path: Path) -> Tuple[bool, List[str]]:
+    errors = []
+    
+    python_files = list(project_path.rglob("*.py"))
+    if not python_files:
+        errors.append("No Python files found in project")
+    
+    has_setup = (
+        (project_path / "setup.py").exists() or
+        (project_path / "pyproject.toml").exists() or
+        (project_path / "setup.cfg").exists()
+    )
+    
+    if not has_setup and not python_files:
+        errors.append("Project does not appear to be a valid Python project (no setup files or Python files found)")
+    
+    return len(errors) == 0, errors
+
+
+def validate_library_exists(library_name: str) -> Tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "index", "versions", library_name],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        if result.returncode == 0:
+            return True, f"Library '{library_name}' found on PyPI"
+        else:
+            return False, f"Library '{library_name}' not found on PyPI"
+            
+    except subprocess.TimeoutExpired:
+        return False, f"Timeout checking library '{library_name}' on PyPI"
+    except Exception as e:
+        return False, f"Error checking library '{library_name}': {str(e)}"
+
+
+def validate_library_name_format(lib_name: str) -> Tuple[bool, str]:
+    if not lib_name:
+        return False, "Library name cannot be empty"
+    
+    if len(lib_name) > 214:
+        return False, "Library name too long (max 214 characters)"
+    
+    if not re.match(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", lib_name, re.IGNORECASE):
+        return False, "Library name must start and end with alphanumeric character, can contain letters, numbers, periods, hyphens, and underscores"
+    
+    if ".." in lib_name:
+        return False, "Library name cannot contain consecutive periods"
+        
+    if lib_name.startswith("-") or lib_name.endswith("-"):
+        return False, "Library name cannot start or end with hyphen"
+        
+    if lib_name.startswith("_") or lib_name.endswith("_"):
+        return False, "Library name cannot start or end with underscore"
+    
+    return True, f"Library name '{lib_name}' is valid"
+
+
+def find_library_usage(project_path: Path, library_name: str) -> Tuple[bool, List[str]]:
+    usage_patterns = [
+        rf"^import\s+{re.escape(library_name)}\b",
+        rf"^from\s+{re.escape(library_name)}\b",
+        rf"^import\s+{re.escape(library_name.replace('-', '_'))}\b",
+        rf"^from\s+{re.escape(library_name.replace('-', '_'))}\b",
+    ]
+    
+    found_files = []
+    
+    for py_file in project_path.rglob("*.py"):
+        try:
+            with open(py_file, 'r', encoding='utf-8') as f:
+                content = f.read()
+                
+            for pattern in usage_patterns:
+                if re.search(pattern, content, re.MULTILINE):
+                    found_files.append(str(py_file.relative_to(project_path)))
+                    break
+                    
+        except (UnicodeDecodeError, PermissionError):
+            continue
+    
+    return len(found_files) > 0, found_files
+
+
+def validate_migration_feasibility(project_path: Path, remove_lib: str, inject_lib: str) -> Tuple[bool, List[str]]:
+    issues = []
+    
+    has_remove_lib, remove_files = find_library_usage(project_path, remove_lib)
+    if not has_remove_lib:
+        issues.append(f"Library '{remove_lib}' does not appear to be used in the project")
+    
+    has_inject_lib, inject_files = find_library_usage(project_path, inject_lib)
+    if has_inject_lib:
+        issues.append(f"Library '{inject_lib}' is already used in the project. Files: {', '.join(inject_files[:3])}")
+    
+    return len(issues) == 0, issues


### PR DESCRIPTION
## Summary
- Implements CLI interface accepting 3 arguments: `project_path`, `remove_lib`, `inject_lib`
- Adds comprehensive argument validation (path exists, library name format)
- Provides clear error messages and help text with examples
- Defines entry point in pyproject.toml for `uv run diversifier`
- Includes `--dry-run` and `--verbose` flags for testing
- Creates validation infrastructure for future enhancements

## Test plan
- [x] CLI help output displays correctly
- [x] Valid arguments are accepted and processed
- [x] Invalid paths are rejected with clear error messages  
- [x] Invalid library names are rejected with format validation
- [x] Dry run mode shows intended actions without execution
- [x] Entry point works via `uv run diversifier`

Addresses Issue #1 from Epic 1: CLI Interface & Core Architecture

🤖 Generated with [Claude Code](https://claude.ai/code)