### PR TITLE
feat: Add Docker Compose configuration for 4 MCP servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Environment variables for Diversifier MCP servers
+# Copy this file to .env and customize values as needed
+
+# Git configuration for git-mcp server
+GIT_AUTHOR_NAME=Diversifier Bot
+GIT_AUTHOR_EMAIL=diversifier@localhost
+
+# Logging level for all MCP servers (DEBUG, INFO, WARNING, ERROR)
+LOG_LEVEL=INFO
+
+# Docker configuration
+DOCKER_HOST=unix:///var/run/docker.sock

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,35 @@
+# Docker Compose override for development
+# This file is automatically loaded by Docker Compose to extend docker-compose.yml
+
+version: '3.8'
+
+services:
+  fs-mcp:
+    environment:
+      - LOG_LEVEL=DEBUG
+    volumes:
+      # Mount current directory for development
+      - .:/workspace:rw
+    ports:
+      - "8001:8001"
+
+  docker-mcp:
+    environment:
+      - LOG_LEVEL=DEBUG
+    ports:
+      - "8002:8002"
+
+  git-mcp:
+    environment:
+      - LOG_LEVEL=DEBUG
+    ports:
+      - "8003:8003"
+
+  testing-mcp:
+    environment:
+      - LOG_LEVEL=DEBUG
+    volumes:
+      # Mount tests directory for development
+      - ./tests:/workspace/tests:rw
+    ports:
+      - "8004:8004"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,135 @@
+version: '3.8'
+
+services:
+  # File System MCP Server - Python file analysis, import parsing, code modification
+  fs-mcp:
+    image: diversifier/fs-mcp:latest
+    container_name: diversifier-fs-mcp
+    build:
+      context: ./mcp-servers/fs-mcp
+      dockerfile: Dockerfile
+    environment:
+      - MCP_SERVER_NAME=fs-mcp
+      - MCP_SERVER_PORT=8001
+      - LOG_LEVEL=INFO
+    volumes:
+      - project-data:/workspace
+      - ./src:/app/src:ro
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+
+  # Docker MCP Server - Container lifecycle management, image building, test execution
+  docker-mcp:
+    image: diversifier/docker-mcp:latest
+    container_name: diversifier-docker-mcp
+    build:
+      context: ./mcp-servers/docker-mcp
+      dockerfile: Dockerfile
+    environment:
+      - MCP_SERVER_NAME=docker-mcp
+      - MCP_SERVER_PORT=8002
+      - LOG_LEVEL=INFO
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - project-data:/workspace
+      - docker-cache:/var/lib/docker
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    privileged: true
+
+  # Git MCP Server - Version control operations, branch management, change tracking
+  git-mcp:
+    image: diversifier/git-mcp:latest
+    container_name: diversifier-git-mcp
+    build:
+      context: ./mcp-servers/git-mcp
+      dockerfile: Dockerfile
+    environment:
+      - MCP_SERVER_NAME=git-mcp
+      - MCP_SERVER_PORT=8003
+      - LOG_LEVEL=INFO
+      - GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-Diversifier Bot}
+      - GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-diversifier@localhost}
+    volumes:
+      - project-data:/workspace
+      - git-config:/root/.gitconfig:ro
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+
+  # Testing MCP Server - pytest execution, result analysis, coverage reporting
+  testing-mcp:
+    image: diversifier/testing-mcp:latest
+    container_name: diversifier-testing-mcp
+    build:
+      context: ./mcp-servers/testing-mcp
+      dockerfile: Dockerfile
+    environment:
+      - MCP_SERVER_NAME=testing-mcp
+      - MCP_SERVER_PORT=8004
+      - LOG_LEVEL=INFO
+      - PYTHONPATH=/workspace
+    volumes:
+      - project-data:/workspace
+      - test-results:/test-results
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+
+networks:
+  mcp-network:
+    driver: bridge
+    name: diversifier-mcp-network
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1
+
+volumes:
+  # Shared volume for project data across all MCP servers
+  project-data:
+    driver: local
+    name: diversifier-project-data
+  
+  # Docker cache volume for docker-mcp server
+  docker-cache:
+    driver: local
+    name: diversifier-docker-cache
+  
+  # Test results volume for testing-mcp server
+  test-results:
+    driver: local
+    name: diversifier-test-results
+  
+  # Git configuration volume
+  git-config:
+    driver: local
+    name: diversifier-git-config


### PR DESCRIPTION
## Summary
- Implements Docker Compose infrastructure for all 4 MCP servers (fs-mcp, docker-mcp, git-mcp, testing-mcp)
- Configures shared networking and volume mounts for data sharing between services
- Adds health checks and proper restart policies for service reliability
- Includes development override file for local development with port mappings

## Test plan
- [ ] Verify docker-compose.yml syntax is valid
- [ ] Test that all 4 services can be built (when Dockerfiles are implemented)
- [ ] Validate network connectivity between services
- [ ] Confirm volume mounts work correctly for shared data
- [ ] Test health check endpoints respond correctly

Resolves #10

🤖 Generated with [Claude Code](https://claude.ai/code)