### PR TITLE
fix: Update main.py to properly use CLI entry point

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
-def main():
-    print("Hello from diversifier!")
+"""Main entry point for direct execution."""
 
+from src.cli import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Replace placeholder implementation in main.py with proper CLI import
- Ensures direct execution (`python main.py`) routes through `src.cli:main`
- Maintains consistency with pyproject.toml entry point configuration
- Completes Epic 3 cleanup and validation after Issue #15 completion

## Changes
- Updated `main.py` to import and call `src.cli.main()` instead of placeholder print statement
- Added proper module docstring for clarity

## Context
This addresses the final cleanup item after completing Epic 3: Library-Independent Acceptance Test Generation. All functionality was already implemented, but the main.py entry point was using a placeholder implementation.

## Testing
- ✅ All 439 tests pass
- ✅ Flake8 linting clean
- ✅ MyPy type checking clean  
- ✅ Black formatting applied
- ✅ CLI functionality works through both `uv run diversifier` and `python main.py`

🤖 Generated with [Claude Code](https://claude.ai/code)