### PR TITLE
feat: Add LangSmith tracing support for workflow monitoring (#71)

### DIFF
--- a/.github/workflows/test-generation-validation.yml
+++ b/.github/workflows/test-generation-validation.yml
@@ -110,6 +110,16 @@ jobs:
         # Set up environment for test generation
         export GOOGLE_API_KEY="${{ secrets.GEMINI_API_KEY }}"
         
+        # Set up LangSmith tracing if API key is available
+        if [ -n "$LANGSMITH_API_KEY" ]; then
+          echo "✅ Enabling LangSmith tracing"
+          export LANGSMITH_TRACING="true"
+          export LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
+          export LANGSMITH_PROJECT="pr-pertinent-youth-30"
+        else
+          echo "⚠️  LangSmith API key not found, tracing disabled"
+        fi
+        
         # Use config file approach
         echo "Starting test generation workflow with config file..."
         
@@ -147,6 +157,7 @@ jobs:
         echo "Continuing with artifact collection..."
       env:
         GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
 
     - name: Analyze generated tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "gitpython>=3.1.45",
     "langchain-anthropic>=0.3.18",
     "langchain-google-genai>=2.1.9",
+    "langsmith>=0.2.32",
 ]
 
 [project.scripts]

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,6 +10,7 @@ from .validation import (
 from .orchestration.coordinator import DiversificationCoordinator
 from .orchestration.config import LoggingConfig, get_config, ConfigManager
 from .orchestration.logging_config import setup_logging
+from .orchestration.langsmith_config import setup_langsmith_tracing
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -119,6 +120,9 @@ async def run_diversification(args) -> int:
 def main() -> int:
     parser = create_parser()
     args = parser.parse_args()
+
+    # Setup LangSmith tracing if configured
+    setup_langsmith_tracing()
 
     # Handle config file creation
     if args.create_config:

--- a/src/orchestration/langsmith_config.py
+++ b/src/orchestration/langsmith_config.py
@@ -1,0 +1,56 @@
+"""LangSmith tracing configuration for Diversifier."""
+
+import os
+from typing import Optional
+
+
+def setup_langsmith_tracing() -> bool:
+    """Configure LangSmith tracing if enabled via environment variables.
+
+    Expected environment variables:
+    - LANGSMITH_TRACING: Set to "true" to enable tracing
+    - LANGSMITH_ENDPOINT: LangSmith API endpoint (defaults to https://api.smith.langchain.com)
+    - LANGSMITH_API_KEY: API key for LangSmith
+    - LANGSMITH_PROJECT: Project name for traces
+
+    Returns:
+        True if tracing was successfully configured, False otherwise
+    """
+    # Check if tracing is enabled
+    tracing_enabled = os.getenv("LANGSMITH_TRACING", "").lower() == "true"
+
+    if not tracing_enabled:
+        return False
+
+    # Get required environment variables
+    api_key = os.getenv("LANGSMITH_API_KEY")
+    project = os.getenv("LANGSMITH_PROJECT", "diversifier")
+    endpoint = os.getenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+    if not api_key:
+        print("Warning: LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY is not set")
+        return False
+
+    # Set LangSmith environment variables for the langsmith package
+    os.environ["LANGCHAIN_TRACING_V2"] = "true"
+    os.environ["LANGCHAIN_ENDPOINT"] = endpoint
+    os.environ["LANGCHAIN_API_KEY"] = api_key
+    os.environ["LANGCHAIN_PROJECT"] = project
+
+    print(f"✅ LangSmith tracing enabled for project: {project}")
+    return True
+
+
+def get_langsmith_status() -> dict[str, Optional[str]]:
+    """Get current LangSmith configuration status.
+
+    Returns:
+        Dictionary containing LangSmith configuration information
+    """
+    return {
+        "tracing_enabled": os.getenv("LANGSMITH_TRACING", "false"),
+        "endpoint": os.getenv("LANGSMITH_ENDPOINT"),
+        "project": os.getenv("LANGSMITH_PROJECT"),
+        "api_key_set": "Yes" if os.getenv("LANGSMITH_API_KEY") else "No",
+        "langchain_tracing": os.getenv("LANGCHAIN_TRACING_V2", "false"),
+    }

--- a/tests/test_langsmith_config.py
+++ b/tests/test_langsmith_config.py
@@ -1,0 +1,90 @@
+"""Tests for LangSmith tracing configuration."""
+
+import os
+from unittest.mock import patch
+
+from src.orchestration.langsmith_config import (
+    setup_langsmith_tracing,
+    get_langsmith_status,
+)
+
+
+class TestLangSmithConfig:
+    """Test LangSmith configuration functionality."""
+
+    def test_setup_langsmith_tracing_disabled_by_default(self):
+        """Test that LangSmith tracing is disabled by default."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = setup_langsmith_tracing()
+            assert result is False
+
+    def test_setup_langsmith_tracing_enabled_without_api_key(self, capsys):
+        """Test that LangSmith tracing shows warning when API key is missing."""
+        with patch.dict(os.environ, {"LANGSMITH_TRACING": "true"}, clear=True):
+            result = setup_langsmith_tracing()
+            assert result is False
+            captured = capsys.readouterr()
+            assert "LANGSMITH_API_KEY is not set" in captured.out
+
+    def test_setup_langsmith_tracing_enabled_with_api_key(self, capsys):
+        """Test that LangSmith tracing is properly configured with API key."""
+        env_vars = {
+            "LANGSMITH_TRACING": "true",
+            "LANGSMITH_API_KEY": "test-api-key",
+            "LANGSMITH_PROJECT": "test-project",
+            "LANGSMITH_ENDPOINT": "https://api.smith.langchain.com",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = setup_langsmith_tracing()
+            assert result is True
+
+            # Check that LangChain environment variables are set
+            assert os.environ.get("LANGCHAIN_TRACING_V2") == "true"
+            assert os.environ.get("LANGCHAIN_API_KEY") == "test-api-key"
+            assert os.environ.get("LANGCHAIN_PROJECT") == "test-project"
+            assert (
+                os.environ.get("LANGCHAIN_ENDPOINT")
+                == "https://api.smith.langchain.com"
+            )
+
+            captured = capsys.readouterr()
+            assert "LangSmith tracing enabled for project: test-project" in captured.out
+
+    def test_setup_langsmith_tracing_uses_defaults(self):
+        """Test that LangSmith uses default values when not specified."""
+        env_vars = {"LANGSMITH_TRACING": "true", "LANGSMITH_API_KEY": "test-api-key"}
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = setup_langsmith_tracing()
+            assert result is True
+
+            assert os.environ.get("LANGCHAIN_PROJECT") == "diversifier"
+            assert (
+                os.environ.get("LANGCHAIN_ENDPOINT")
+                == "https://api.smith.langchain.com"
+            )
+
+    def test_get_langsmith_status(self):
+        """Test that status reporting works correctly."""
+        env_vars = {
+            "LANGSMITH_TRACING": "true",
+            "LANGSMITH_API_KEY": "test-key",
+            "LANGSMITH_PROJECT": "test-project",
+            "LANGSMITH_ENDPOINT": "https://test.com",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            status = get_langsmith_status()
+            assert status["tracing_enabled"] == "true"
+            assert status["project"] == "test-project"
+            assert status["endpoint"] == "https://test.com"
+            assert status["api_key_set"] == "Yes"
+
+    def test_get_langsmith_status_no_config(self):
+        """Test status reporting when no configuration is present."""
+        with patch.dict(os.environ, {}, clear=True):
+            status = get_langsmith_status()
+            assert status["tracing_enabled"] == "false"
+            assert status["api_key_set"] == "No"
+            assert status["langchain_tracing"] == "false"

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,7 @@ dependencies = [
     { name = "langchain-google-genai" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "langsmith" },
     { name = "mcp" },
 ]
 
@@ -252,6 +253,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=2.1.9" },
     { name = "langchain-openai", specifier = ">=0.2.14" },
     { name = "langgraph", specifier = ">=0.6.4" },
+    { name = "langsmith", specifier = ">=0.2.32" },
     { name = "mcp", specifier = ">=1.1.0" },
 ]
 


### PR DESCRIPTION
## Summary
- Adds LangSmith tracing support to enable workflow monitoring and debugging
- Implements environment variable-based configuration for easy setup
- Updates GitHub Actions to use the new LANGSMITH_API_KEY secret

## Changes Made
- Added `langsmith>=0.2.32` dependency to `pyproject.toml`
- Created `src/orchestration/langsmith_config.py` with tracing configuration logic
- Integrated LangSmith setup in CLI entry point (`src/cli.py`)
- Updated GitHub Actions workflow to use `LANGSMITH_API_KEY` secret
- Added comprehensive tests for LangSmith configuration

## Environment Variables
The implementation supports these environment variables:
- `LANGSMITH_TRACING="true"` - Enable tracing (required)
- `LANGSMITH_ENDPOINT` - API endpoint (defaults to https://api.smith.langchain.com)
- `LANGSMITH_API_KEY` - API key (required)
- `LANGSMITH_PROJECT` - Project name (defaults to "diversifier", GitHub Actions uses "pr-pertinent-youth-30")

## Test Plan
- [x] All existing tests pass
- [x] New tests added for LangSmith configuration functionality
- [x] Code quality checks (ruff, mypy, black) pass
- [x] GitHub Actions workflow updated to conditionally enable tracing

## Implementation Details
- Tracing is disabled by default and only enabled when explicitly configured
- Graceful handling of missing API keys with warning messages
- Integration with LangChain's tracing system via environment variables
- Comprehensive test coverage for all configuration scenarios

Fixes #71

🤖 Generated with [Claude Code](https://claude.ai/code)