### PR TITLE
fix: Add missing interface methods to DockerMCPLauncher to resolve #73

### DIFF
--- a/src/mcp_servers/docker/launcher.py
+++ b/src/mcp_servers/docker/launcher.py
@@ -3,8 +3,9 @@
 import argparse
 import subprocess
 import sys
+import json
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
 
 
 class DockerMCPLauncher:
@@ -20,31 +21,46 @@ class DockerMCPLauncher:
         self.project_root = project_root or str(Path.cwd())
         self.process: Optional[subprocess.Popen] = None
 
-    def start(self) -> subprocess.Popen:
+    def start_server(self) -> bool:
         """Start the Docker MCP Server as a subprocess.
+
+        Returns:
+            True if server started successfully, False otherwise.
+        """
+        try:
+            server_module = Path(__file__).parent / "server.py"
+
+            # Start server process
+            cmd = [sys.executable, str(server_module)]
+            if self.project_root:
+                cmd.append(self.project_root)
+
+            self.process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=0,  # Unbuffered for real-time communication
+            )
+
+            return True
+
+        except Exception as e:
+            print(f"Failed to start Docker MCP Server: {e}")
+            return False
+
+    def start(self) -> subprocess.Popen:
+        """Start the Docker MCP Server as a subprocess (legacy method).
 
         Returns:
             The subprocess.Popen object for the server process.
         """
-        server_module = Path(__file__).parent / "server.py"
+        if self.start_server() and self.process:
+            return self.process
+        raise RuntimeError("Failed to start Docker MCP Server")
 
-        # Start server process
-        cmd = [sys.executable, str(server_module)]
-        if self.project_root:
-            cmd.append(self.project_root)
-
-        self.process = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=0,  # Unbuffered for real-time communication
-        )
-
-        return self.process
-
-    def stop(self) -> None:
+    def stop_server(self) -> None:
         """Stop the Docker MCP Server process."""
         if self.process:
             self.process.terminate()
@@ -55,6 +71,63 @@ class DockerMCPLauncher:
                 self.process.wait()
             finally:
                 self.process = None
+
+    def stop(self) -> None:
+        """Stop the Docker MCP Server process (legacy method)."""
+        self.stop_server()
+
+    def send_request(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Send a JSON-RPC request to the server.
+
+        Args:
+            method: Method name to call
+            params: Parameters for the method
+
+        Returns:
+            Response from server or None if error
+        """
+        if not self.process:
+            return None
+
+        request = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}}
+
+        try:
+            # Send request
+            request_json = json.dumps(request) + "\n"
+            if self.process.stdin:
+                self.process.stdin.write(request_json)
+                self.process.stdin.flush()
+
+            # Read response
+            if self.process.stdout:
+                response_line = self.process.stdout.readline()
+                if response_line:
+                    return json.loads(response_line.strip())
+
+        except Exception as e:
+            print(f"Error communicating with Docker MCP server: {e}")
+
+        return None
+
+    def list_tools(self) -> Optional[Dict[str, Any]]:
+        """List available tools."""
+        return self.send_request("tools/list")
+
+    def call_tool(
+        self, name: str, arguments: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Call a specific tool.
+
+        Args:
+            name: Tool name
+            arguments: Tool arguments
+
+        Returns:
+            Tool result
+        """
+        return self.send_request("tools/call", {"name": name, "arguments": arguments})
 
     def is_running(self) -> bool:
         """Check if the Docker MCP Server process is running."""


### PR DESCRIPTION
## Summary
- Fixes Docker MCP initialization failure in issue #73
- Adds required interface methods to DockerMCPLauncher for consistency with other MCP clients
- Maintains backward compatibility with existing code

## Root Cause
The Docker MCP server was failing to initialize because `DockerMCPLauncher` was missing the `start_server()` method that `MCPConnection.connect()` expects. Other MCP clients (FileSystem, Git, Testing) all implement this standard interface.

The error message was:
```
WARNING  diversifier.mcp.docker    | Client for docker does not support connection
```

## Changes Made
1. **Added `start_server()` method** - Returns boolean indicating success/failure
2. **Added `stop_server()` method** - Properly stops the MCP server process  
3. **Added JSON-RPC communication methods**:
   - `send_request()` - Send JSON-RPC requests to server
   - `call_tool()` - Call specific tools on the server
   - `list_tools()` - List available tools from server
4. **Maintained backward compatibility** - Legacy `start()`/`stop()` methods still work

## Test Plan
- [x] All existing unit tests pass (445 tests)
- [x] Linting passes with ruff
- [x] Type checking passes with mypy
- [x] Code formatting verified with black
- [x] Manual verification that DockerMCPLauncher now has all required interface methods
- [x] Confirmed MCPConnection can successfully create connection with DockerMCPLauncher

## Impact
This fix ensures that all 4 MCP servers (filesystem, testing, git, docker) can initialize properly during the diversification workflow. The Docker MCP server will now be available for containerized testing and validation operations.

Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/code)