### PR TITLE
Remove dry-run option to simplify project complexity

### DIFF
--- a/.github/workflows/test-generation-validation.yml
+++ b/.github/workflows/test-generation-validation.yml
@@ -125,8 +125,8 @@ jobs:
         
         set +e  # Don't fail immediately on error so we can capture partial results
         
-        # Run diversifier using config file with dry-run to prevent actual migration
-        uv run diversifier pilot-project emails redmail --config diversifier_config.toml --dry-run --verbose 2>&1 | tee diversifier_output.log
+        # Run diversifier using config file
+        uv run diversifier pilot-project emails redmail --config diversifier_config.toml --verbose 2>&1 | tee diversifier_output.log
         
         DIVERSIFIER_EXIT_CODE=$?
         

--- a/src/cli.py
+++ b/src/cli.py
@@ -109,11 +109,6 @@ Examples:
         help="Name of the library to inject/substitute",
     )
 
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without making changes",
-    )
 
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose output"
@@ -159,7 +154,7 @@ async def run_diversification(args) -> int:
 
         # Execute workflow
         success = await coordinator.execute_workflow(
-            dry_run=args.dry_run, auto_proceed=True  # For now, auto-proceed in CLI mode
+            auto_proceed=True  # For now, auto-proceed in CLI mode
         )
 
         if success:
@@ -236,7 +231,6 @@ def main() -> int:
         print(f"Project path: {project_path}")
         print(f"Remove library: {args.remove_lib}")
         print(f"Inject library: {args.inject_lib}")
-        print(f"Dry run: {args.dry_run}")
 
     # Store validated path
     args.project_path = project_path

--- a/src/cli.py
+++ b/src/cli.py
@@ -109,7 +109,6 @@ Examples:
         help="Name of the library to inject/substitute",
     )
 
-
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose output"
     )

--- a/src/orchestration/coordinator.py
+++ b/src/orchestration/coordinator.py
@@ -75,7 +75,6 @@ class DiversificationCoordinator:
         self.logger = logging.getLogger("diversifier.coordinator")
 
         # Configuration
-        self.dry_run = False
         self.auto_proceed = False
 
     def _validate_api_key(self) -> bool:
@@ -117,18 +116,16 @@ class DiversificationCoordinator:
             return False
 
     async def execute_workflow(
-        self, dry_run: bool = False, auto_proceed: bool = False
+        self, auto_proceed: bool = False
     ) -> bool:
         """Execute the complete diversification workflow.
 
         Args:
-            dry_run: If True, don't make actual changes
             auto_proceed: If True, don't wait for user confirmation
 
         Returns:
             True if workflow completed successfully
         """
-        self.dry_run = dry_run
         self.auto_proceed = auto_proceed
 
         self.logger.info(
@@ -250,9 +247,6 @@ class DiversificationCoordinator:
     async def _create_backup(self) -> Dict[str, Any]:
         """Create backup of project before migration."""
         try:
-            if self.dry_run:
-                self.logger.info("Dry run: Skipping backup creation")
-                return {"success": True, "backup_path": None}
 
             # Use git MCP server to create backup branch
             if self.mcp_manager.is_server_available(MCPServerType.GIT):
@@ -384,18 +378,6 @@ class DiversificationCoordinator:
                 f"Found {len(test_functions)} unique tests covering library usage"
             )
 
-            if self.dry_run:
-                self.logger.info("Dry run: Skipping actual test execution")
-                return {
-                    "success": True,
-                    "test_results": {
-                        "tests_executed": len(test_functions),
-                        "passed": len(test_functions),
-                        "failed": 0,
-                        "note": "Dry run - tests not actually executed",
-                        "selected_tests": list(test_functions),
-                    },
-                }
 
             # Use LLM-powered test running for intelligent test execution
             self.logger.info("Using LLM-powered test runner to execute tests")
@@ -561,11 +543,7 @@ class DiversificationCoordinator:
             Perform the migration while preserving all functionality.
             """
 
-            if self.dry_run:
-                self.logger.info("Dry run: Simulating code migration")
-                result = {"output": "Dry run migration simulation"}
-            else:
-                result = migrator.invoke(migration_prompt)
+            result = migrator.invoke(migration_prompt)
 
             return {
                 "success": True,
@@ -635,11 +613,7 @@ class DiversificationCoordinator:
             Apply targeted fixes to resolve the issues while maintaining functional equivalence.
             """
 
-            if self.dry_run:
-                self.logger.info("Dry run: Simulating issue repair")
-                result = {"output": "Dry run repair simulation"}
-            else:
-                result = repairer.invoke(repair_prompt)
+            result = repairer.invoke(repair_prompt)
 
             return {
                 "success": True,
@@ -656,13 +630,6 @@ class DiversificationCoordinator:
         try:
             self.logger.info("Finalizing migration")
 
-            if self.dry_run:
-                self.logger.info("Dry run: Simulating migration finalization")
-                return {
-                    "success": True,
-                    "migration_finalized": True,
-                    "cleanup_complete": True,
-                }
 
             # Use git MCP server for cleanup when available
             if self.mcp_manager.is_server_available(MCPServerType.GIT):

--- a/src/orchestration/coordinator.py
+++ b/src/orchestration/coordinator.py
@@ -115,9 +115,7 @@ class DiversificationCoordinator:
 
             return False
 
-    async def execute_workflow(
-        self, auto_proceed: bool = False
-    ) -> bool:
+    async def execute_workflow(self, auto_proceed: bool = False) -> bool:
         """Execute the complete diversification workflow.
 
         Args:
@@ -378,7 +376,6 @@ class DiversificationCoordinator:
                 f"Found {len(test_functions)} unique tests covering library usage"
             )
 
-
             # Use LLM-powered test running for intelligent test execution
             self.logger.info("Using LLM-powered test runner to execute tests")
             return await self._run_tests_with_llm(test_functions)
@@ -629,7 +626,6 @@ class DiversificationCoordinator:
         """Clean up and finalize migration."""
         try:
             self.logger.info("Finalizing migration")
-
 
             # Use git MCP server for cleanup when available
             if self.mcp_manager.is_server_available(MCPServerType.GIT):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,6 @@ class TestCreateParser:
         assert args.project_path == "."
         assert args.remove_lib == "requests"
         assert args.inject_lib == "httpx"
-        assert args.dry_run is False
         assert args.verbose is False
 
     def test_parser_optional_flags(self):
@@ -43,11 +42,9 @@ class TestCreateParser:
                 ".",
                 "requests",
                 "httpx",
-                "--dry-run",
                 "--verbose",
             ]
         )
-        assert args.dry_run is True
         assert args.verbose is True
 
     def test_parser_help_output(self):
@@ -65,54 +62,6 @@ class TestCreateParser:
 
 
 class TestMainFunction:
-    @patch("src.cli.get_config")
-    @patch("src.cli.DiversificationCoordinator")
-    @patch("src.cli.validate_library_name")
-    @patch("src.cli.validate_project_path")
-    @patch("src.cli.validate_python_project")
-    @patch("builtins.print")
-    def test_main_dry_run_success(
-        self,
-        mock_print,
-        mock_validate_python,
-        mock_validate_path,
-        mock_validate_lib,
-        mock_coordinator_class,
-        mock_get_config,
-    ):
-
-        # Mock LLM config and migration config
-        mock_llm_config = Mock(spec=LLMConfig)
-        mock_migration_config = Mock()
-        mock_migration_config.test_paths = ["tests/"]
-        mock_config = Mock(spec=DiversifierConfig)
-        mock_config.llm = mock_llm_config
-        mock_config.migration = mock_migration_config
-        mock_get_config.return_value = mock_config
-
-        mock_validate_python.return_value = (True, [])
-        mock_validate_path.return_value = "/fake/path"
-        mock_validate_lib.return_value = True
-        mock_coordinator = Mock()
-        # Mock the async execute_workflow method
-        mock_coordinator.execute_workflow = AsyncMock(return_value=True)
-        mock_coordinator_class.return_value = mock_coordinator
-
-        test_args = [
-            "diversifier",
-            "--config",
-            "/test/config.toml",
-            ".",
-            "requests",
-            "httpx",
-            "--dry-run",
-            "--verbose",
-        ]
-        with patch.object(sys, "argv", test_args):
-            result = main()
-
-        assert result == 0
-        mock_validate_python.assert_called_once()
 
     @patch("src.cli.get_config")
     @patch("src.cli.validate_python_project")
@@ -269,7 +218,6 @@ class TestMainFunction:
             "requests",
             "httpx",
             "--verbose",
-            "--dry-run",
         ]
         with patch.object(sys, "argv", test_args):
             result = main()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -697,7 +697,6 @@ class TestDiversificationCoordinator:
         assert isinstance(coordinator.mcp_manager, MCPManager)
         assert isinstance(coordinator.workflow_state, WorkflowState)
 
-
     @patch.dict(os.environ, {"TEST_API_KEY": "test-key"}, clear=False)
     def test_get_workflow_status(self):
         """Test getting workflow status."""

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -697,47 +697,6 @@ class TestDiversificationCoordinator:
         assert isinstance(coordinator.mcp_manager, MCPManager)
         assert isinstance(coordinator.workflow_state, WorkflowState)
 
-    @pytest.mark.asyncio
-    @patch.dict(os.environ, {"TEST_API_KEY": "test-key"}, clear=False)
-    async def test_execute_workflow_dry_run(self):
-        """Test workflow execution in dry run mode."""
-
-        llm_config = LLMConfig(
-            provider="anthropic",
-            model_name="claude-3-sonnet",
-            api_key_env_var="TEST_API_KEY",
-        )
-        coordinator = DiversificationCoordinator(
-            project_path=self.project_path,
-            source_library="requests",
-            target_library="httpx",
-            llm_config=llm_config,
-        )
-
-        # Mock all the step handlers to return success
-        with (
-            patch.object(
-                coordinator, "_initialize_environment", return_value={"success": True}
-            ),
-            patch.object(coordinator, "_create_backup", return_value={"success": True}),
-            patch.object(coordinator, "_select_tests", return_value={"success": True}),
-            patch.object(
-                coordinator, "_run_baseline_tests", return_value={"success": True}
-            ),
-            patch.object(coordinator, "_migrate_code", return_value={"success": True}),
-            patch.object(
-                coordinator, "_validate_migration", return_value={"success": True}
-            ),
-            patch.object(coordinator, "_repair_issues", return_value={"success": True}),
-            patch.object(
-                coordinator, "_finalize_migration", return_value={"success": True}
-            ),
-        ):
-
-            result = await coordinator.execute_workflow(dry_run=True, auto_proceed=True)
-
-            assert result is True
-            assert coordinator.workflow_state.is_workflow_complete()
 
     @patch.dict(os.environ, {"TEST_API_KEY": "test-key"}, clear=False)
     def test_get_workflow_status(self):


### PR DESCRIPTION
## Summary
- Removes the --dry-run CLI flag and all associated dry-run functionality throughout the codebase
- Eliminates dry-run simulation logic from all workflow steps in the coordinator
- Removes dry-run related tests and updates GitHub workflow
- Applies code formatting with black

## Test plan
- [x] All existing tests pass (372 tests)
- [x] Linting passes (ruff)
- [x] Type checking passes (mypy)
- [x] Code formatting applied (black)
- [x] Quality checks completed successfully

This simplifies the codebase by eliminating the complexity of maintaining dual execution paths for actual operations and dry-run simulations, making the project easier to understand and maintain.

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)