### PR TITLE
feat: Remove log-level, log-file and verbose args, simplify LoggingConfig (#93)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -41,7 +41,7 @@ def _cleanup_on_exit() -> None:
             print(f"⚠️  Error during cleanup: {e}")
 
 
-def _signal_handler(signum: int, frame) -> None:
+def _signal_handler(signum: int, frame=None) -> None:
     """Handle termination signals by cleaning up coordinator resources."""
     signal_name = signal.Signals(signum).name
     print(f"\n🛑 Received {signal_name}, shutting down gracefully...")
@@ -113,15 +113,6 @@ Examples:
         "--verbose", "-v", action="store_true", help="Enable verbose output"
     )
 
-    parser.add_argument(
-        "--log-level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
-        help="Set logging level (default: INFO)",
-    )
-
-    parser.add_argument("--log-file", type=str, help="Write logs to file")
-
     return parser
 
 
@@ -129,16 +120,16 @@ async def run_diversification(args) -> int:
     """Run the diversification workflow."""
     global _coordinator
 
-    # Setup logging
-    log_level = "DEBUG" if args.verbose else args.log_level
-    logging_config = LoggingConfig(
-        level=log_level, console=True, file_path=args.log_file
-    )
-    setup_logging(logging_config)
-
     try:
         # Initialize coordinator with configuration from config file
         config = get_config(args.config)
+
+        # Setup logging
+        log_level = "DEBUG" if args.verbose else config.logging.level
+        logging_config = LoggingConfig(
+            level=log_level, format_string=config.logging.format_string
+        )
+        setup_logging(logging_config)
 
         coordinator = DiversificationCoordinator(
             project_path=str(args.project_path),

--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -12,12 +12,7 @@ class LoggingConfig:
     """Logging configuration settings."""
 
     level: str = "INFO"
-    console: bool = True
-    file_path: Optional[str] = None
-    max_file_size: int = 10 * 1024 * 1024  # 10MB
-    backup_count: int = 5
     format_string: str = "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
-    enable_correlation_ids: bool = True
 
 
 @dataclass
@@ -195,11 +190,6 @@ class ConfigManager:
         env_mappings = {
             # Logging configuration
             "DIVERSIFIER_LOG_LEVEL": ("logging", "level"),
-            "DIVERSIFIER_LOG_FILE": ("logging", "file_path"),
-            "DIVERSIFIER_LOG_CONSOLE": ("logging", "console"),
-            "DIVERSIFIER_LOG_MAX_SIZE": ("logging", "max_file_size"),
-            "DIVERSIFIER_LOG_BACKUP_COUNT": ("logging", "backup_count"),
-            "DIVERSIFIER_CORRELATION_IDS": ("logging", "enable_correlation_ids"),
             # MCP configuration
             "DIVERSIFIER_MCP_TIMEOUT": ("mcp", "timeout"),
             # Migration configuration
@@ -247,18 +237,14 @@ class ConfigManager:
         """
         # Boolean values
         if key in [
-            "console",
             "validate_syntax",
             "require_test_coverage",
-            "enable_correlation_ids",
             "debug_mode",
         ]:
             return value.lower() in ("true", "1", "yes", "on")
 
         # Integer values
         if key in [
-            "max_file_size",
-            "backup_count",
             "timeout",
             "max_iterations",
             "test_timeout",
@@ -370,11 +356,7 @@ class ConfigManager:
 
 [logging]
 level = "INFO"
-console = true
-file_path = "diversifier.log"
-max_file_size = 10485760  # 10MB
-backup_count = 5
-enable_correlation_ids = true
+format_string = "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
 
 [mcp]
 filesystem_server_path = "src/mcp_servers/filesystem/server.py"

--- a/src/orchestration/logging_config.py
+++ b/src/orchestration/logging_config.py
@@ -1,74 +1,22 @@
 """Logging configuration for the orchestration system."""
 
-import contextvars
 import logging
-import logging.handlers
 import sys
-import uuid
-from datetime import datetime
-from pathlib import Path
 from typing import Optional
 
 from .config import LoggingConfig, get_config
 
 
-# Context variable for correlation IDs
-correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "correlation_id", default=""
-)
-
-
 class DiversifierFormatter(logging.Formatter):
     """Custom formatter for diversifier logs."""
 
-    def __init__(self, use_colors: bool = True, enable_correlation_ids: bool = True):
+    def __init__(self, format_string: str):
         """Initialize the formatter.
 
         Args:
-            use_colors: Whether to use color formatting
-            enable_correlation_ids: Whether to include correlation IDs
+            format_string: Format string for log messages
         """
-        super().__init__()
-        self.use_colors = use_colors
-        self.enable_correlation_ids = enable_correlation_ids
-
-        # Color codes for different log levels
-        self.colors = {
-            "DEBUG": "\033[36m",  # Cyan
-            "INFO": "\033[32m",  # Green
-            "WARNING": "\033[33m",  # Yellow
-            "ERROR": "\033[31m",  # Red
-            "CRITICAL": "\033[35m",  # Magenta
-            "ENDC": "\033[0m",  # End color
-        }
-
-    def format(self, record):
-        """Format log record with colors and structure."""
-        # Add timestamp
-        timestamp = datetime.fromtimestamp(record.created).strftime("%Y-%m-%d %H:%M:%S")
-
-        # Get correlation ID if enabled
-        corr_id = ""
-        if self.enable_correlation_ids:
-            current_corr_id = correlation_id.get()
-            if current_corr_id:
-                corr_id = f"[{current_corr_id[:8]}] "
-
-        # Get color for log level
-        color = ""
-        end_color = ""
-        if self.use_colors:
-            color = self.colors.get(record.levelname, "")
-            end_color = self.colors["ENDC"]
-
-        # Format the message
-        formatted = f"{color}[{timestamp}] {corr_id}{record.levelname:8} {record.name:25} | {record.getMessage()}{end_color}"
-
-        # Add exception info if present
-        if record.exc_info:
-            formatted += "\n" + self.formatException(record.exc_info)
-
-        return formatted
+        super().__init__(format_string)
 
 
 def setup_logging(config: Optional[LoggingConfig] = None) -> None:
@@ -90,74 +38,18 @@ def setup_logging(config: Optional[LoggingConfig] = None) -> None:
     # Clear any existing handlers
     root_logger.handlers.clear()
 
-    # Console handler
-    if config.console:
-        console_handler = logging.StreamHandler(sys.stdout)
-        console_handler.setLevel(numeric_level)
-        console_formatter = DiversifierFormatter(
-            use_colors=True, enable_correlation_ids=config.enable_correlation_ids
-        )
-        console_handler.setFormatter(console_formatter)
-        root_logger.addHandler(console_handler)
-
-    # File handler with rotation
-    if config.file_path:
-        log_path = Path(config.file_path)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Use rotating file handler for automatic log rotation
-        file_handler = logging.handlers.RotatingFileHandler(
-            config.file_path,
-            maxBytes=config.max_file_size,
-            backupCount=config.backup_count,
-        )
-        file_handler.setLevel(numeric_level)
-
-        # Use plain formatter for file (no colors) with correlation IDs
-        file_formatter = DiversifierFormatter(
-            use_colors=False, enable_correlation_ids=config.enable_correlation_ids
-        )
-        file_handler.setFormatter(file_formatter)
-        root_logger.addHandler(file_handler)
+    # Console handler only
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(numeric_level)
+    console_formatter = DiversifierFormatter(config.format_string)
+    console_handler.setFormatter(console_formatter)
+    root_logger.addHandler(console_handler)
 
     # Prevent propagation to root logger
     root_logger.propagate = False
 
     # Log setup completion
-    root_logger.info(
-        f"Logging initialized - Level: {config.level}, Console: {config.console}, "
-        f"File: {config.file_path}, Correlation IDs: {config.enable_correlation_ids}"
-    )
-
-
-def set_correlation_id(corr_id: Optional[str] = None) -> str:
-    """Set correlation ID for current context.
-
-    Args:
-        corr_id: Correlation ID to set. If None, generates a new UUID.
-
-    Returns:
-        The correlation ID that was set
-    """
-    if corr_id is None:
-        corr_id = str(uuid.uuid4())
-
-    correlation_id.set(corr_id)
-    return corr_id
-
-
-def get_correlation_id() -> str:
-    """Get current correlation ID.
-
-    Returns:
-        Current correlation ID or empty string if not set
-    """
-    return correlation_id.get()
-
-
-def clear_correlation_id() -> None:
-    """Clear current correlation ID."""
-    correlation_id.set("")
+    root_logger.info(f"Logging initialized - Level: {config.level}")
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class TestCreateParser:
         assert args.inject_lib == "httpx"
         assert args.verbose is False
 
-    def test_parser_optional_flags(self):
+    def test_parser_verbose_flag(self):
         parser = create_parser()
 
         args = parser.parse_args(
@@ -70,13 +70,19 @@ class TestMainFunction:
         self, mock_print, mock_validate_python, mock_get_config
     ):
 
-        # Mock LLM config and migration config
+        # Mock LLM config, migration config, and logging config
         mock_llm_config = Mock(spec=LLMConfig)
         mock_migration_config = Mock()
         mock_migration_config.test_paths = ["tests/"]
+        mock_logging_config = Mock()
+        mock_logging_config.level = "INFO"
+        mock_logging_config.format_string = (
+            "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
+        )
         mock_config = Mock(spec=DiversifierConfig)
         mock_config.llm = mock_llm_config
         mock_config.migration = mock_migration_config
+        mock_config.logging = mock_logging_config
         mock_get_config.return_value = mock_config
 
         mock_validate_python.return_value = (
@@ -121,13 +127,19 @@ class TestMainFunction:
         self, mock_print, mock_validate_python, mock_coordinator_class, mock_get_config
     ):
 
-        # Mock LLM config and migration config
+        # Mock LLM config, migration config, and logging config
         mock_llm_config = Mock(spec=LLMConfig)
         mock_migration_config = Mock()
         mock_migration_config.test_paths = ["tests/"]
+        mock_logging_config = Mock()
+        mock_logging_config.level = "INFO"
+        mock_logging_config.format_string = (
+            "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
+        )
         mock_config = Mock(spec=DiversifierConfig)
         mock_config.llm = mock_llm_config
         mock_config.migration = mock_migration_config
+        mock_config.logging = mock_logging_config
         mock_get_config.return_value = mock_config
 
         mock_validate_python.return_value = (True, [])
@@ -153,13 +165,19 @@ class TestMainFunction:
         self, mock_print, mock_validate_python, mock_coordinator_class, mock_get_config
     ):
 
-        # Mock LLM config and migration config
+        # Mock LLM config, migration config, and logging config
         mock_llm_config = Mock(spec=LLMConfig)
         mock_migration_config = Mock()
         mock_migration_config.test_paths = ["tests/"]
+        mock_logging_config = Mock()
+        mock_logging_config.level = "INFO"
+        mock_logging_config.format_string = (
+            "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
+        )
         mock_config = Mock(spec=DiversifierConfig)
         mock_config.llm = mock_llm_config
         mock_config.migration = mock_migration_config
+        mock_config.logging = mock_logging_config
         mock_get_config.return_value = mock_config
 
         mock_validate_python.return_value = (True, [])
@@ -193,13 +211,19 @@ class TestMainFunction:
         mock_get_config,
     ):
 
-        # Mock LLM config and migration config
+        # Mock LLM config, migration config, and logging config
         mock_llm_config = Mock(spec=LLMConfig)
         mock_migration_config = Mock()
         mock_migration_config.test_paths = ["tests/"]
+        mock_logging_config = Mock()
+        mock_logging_config.level = "INFO"
+        mock_logging_config.format_string = (
+            "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
+        )
         mock_config = Mock(spec=DiversifierConfig)
         mock_config.llm = mock_llm_config
         mock_config.migration = mock_migration_config
+        mock_config.logging = mock_logging_config
         mock_get_config.return_value = mock_config
 
         mock_validate_python.return_value = (True, [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,28 +28,19 @@ class TestLoggingConfig:
         """Test default configuration values."""
         config = LoggingConfig()
         assert config.level == "INFO"
-        assert config.console is True
-        assert config.file_path is None
-        assert config.max_file_size == 10 * 1024 * 1024
-        assert config.backup_count == 5
-        assert config.enable_correlation_ids is True
+        assert (
+            config.format_string
+            == "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
+        )
 
     def test_custom_values(self):
         """Test custom configuration values."""
         config = LoggingConfig(
             level="DEBUG",
-            console=False,
-            file_path="custom.log",
-            max_file_size=5000000,
-            backup_count=3,
-            enable_correlation_ids=False,
+            format_string="%(name)s - %(levelname)s - %(message)s",
         )
         assert config.level == "DEBUG"
-        assert config.console is False
-        assert config.file_path == "custom.log"
-        assert config.max_file_size == 5000000
-        assert config.backup_count == 3
-        assert config.enable_correlation_ids is False
+        assert config.format_string == "%(name)s - %(levelname)s - %(message)s"
 
 
 class TestMCPConfig:
@@ -195,8 +186,7 @@ debug_mode = true
 
 [logging]
 level = "DEBUG"
-console = false
-file_path = "test.log"
+format_string = "%(name)s - %(levelname)s - %(message)s"
 
 [mcp]
 timeout = 60
@@ -221,8 +211,10 @@ api_key_env_var = "OPENAI_API_KEY"
                 config = manager.load_config()
 
                 assert config.logging.level == "DEBUG"
-                assert config.logging.console is False
-                assert config.logging.file_path == "test.log"
+                assert (
+                    config.logging.format_string
+                    == "%(name)s - %(levelname)s - %(message)s"
+                )
                 assert config.mcp.timeout == 60
                 assert config.migration.max_iterations == 10
                 assert config.llm.provider == "openai"
@@ -262,7 +254,6 @@ api_key_env_var = "TEST_API_KEY"
         env_vars = {
             "TEST_API_KEY": "test-key",
             "DIVERSIFIER_LOG_LEVEL": "ERROR",
-            "DIVERSIFIER_LOG_CONSOLE": "false",
             "DIVERSIFIER_MCP_TIMEOUT": "120",
             "DIVERSIFIER_DEBUG": "true",
             "DIVERSIFIER_MIN_COVERAGE": "0.9",
@@ -284,7 +275,6 @@ api_key_env_var = "TEST_API_KEY"
                     config = manager.load_config()
 
                     assert config.logging.level == "ERROR"
-                    assert config.logging.console is False
                     assert config.mcp.timeout == 120
                     assert config.debug_mode is True
                     assert config.migration.min_test_coverage == 0.9
@@ -300,17 +290,17 @@ api_key_env_var = "TEST_API_KEY"
         manager = ConfigManager("/dummy/path.toml")
 
         # Test true values
-        assert manager._convert_env_value("true", "console") is True
-        assert manager._convert_env_value("1", "console") is True
-        assert manager._convert_env_value("yes", "console") is True
-        assert manager._convert_env_value("on", "console") is True
-        assert manager._convert_env_value("TRUE", "console") is True
+        assert manager._convert_env_value("true", "debug_mode") is True
+        assert manager._convert_env_value("1", "debug_mode") is True
+        assert manager._convert_env_value("yes", "debug_mode") is True
+        assert manager._convert_env_value("on", "debug_mode") is True
+        assert manager._convert_env_value("TRUE", "debug_mode") is True
 
         # Test false values
-        assert manager._convert_env_value("false", "console") is False
-        assert manager._convert_env_value("0", "console") is False
-        assert manager._convert_env_value("no", "console") is False
-        assert manager._convert_env_value("off", "console") is False
+        assert manager._convert_env_value("false", "debug_mode") is False
+        assert manager._convert_env_value("0", "debug_mode") is False
+        assert manager._convert_env_value("no", "debug_mode") is False
+        assert manager._convert_env_value("off", "debug_mode") is False
 
     def test_convert_env_value_integer(self):
         """Test environment value conversion for integers."""

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,25 +1,17 @@
 """Tests for logging configuration."""
 
-import contextvars
 import logging
-import sys
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
 from src.orchestration.config import LoggingConfig
 from src.orchestration.logging_config import (
     DiversifierFormatter,
-    clear_correlation_id,
-    correlation_id,
-    get_correlation_id,
     get_logger,
     log_agent_interaction,
     log_mcp_operation,
     log_migration_progress,
     log_workflow_step,
-    set_correlation_id,
     setup_logging,
 )
 
@@ -27,22 +19,16 @@ from src.orchestration.logging_config import (
 class TestDiversifierFormatter:
     """Tests for DiversifierFormatter class."""
 
-    def test_init_default(self):
-        """Test formatter initialization with defaults."""
-        formatter = DiversifierFormatter()
-        assert formatter.use_colors is True
-        assert formatter.enable_correlation_ids is True
-        assert len(formatter.colors) == 6  # 5 levels + ENDC
-
-    def test_init_custom(self):
-        """Test formatter initialization with custom settings."""
-        formatter = DiversifierFormatter(use_colors=False, enable_correlation_ids=False)
-        assert formatter.use_colors is False
-        assert formatter.enable_correlation_ids is False
+    def test_init_with_format_string(self):
+        """Test formatter initialization with format string."""
+        format_string = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+        formatter = DiversifierFormatter(format_string)
+        assert formatter._style._fmt == format_string
 
     def test_format_basic_record(self):
         """Test formatting a basic log record."""
-        formatter = DiversifierFormatter(use_colors=False, enable_correlation_ids=False)
+        format_string = "%(levelname)s | %(name)s | %(message)s"
+        formatter = DiversifierFormatter(format_string)
         record = logging.LogRecord(
             name="test.logger",
             level=logging.INFO,
@@ -57,127 +43,6 @@ class TestDiversifierFormatter:
         assert "INFO" in formatted
         assert "test.logger" in formatted
         assert "Test message" in formatted
-        assert "[" in formatted  # timestamp bracket
-
-    def test_format_with_colors(self):
-        """Test formatting with colors enabled."""
-        formatter = DiversifierFormatter(use_colors=True, enable_correlation_ids=False)
-        record = logging.LogRecord(
-            name="test.logger",
-            level=logging.ERROR,
-            pathname="",
-            lineno=1,
-            msg="Error message",
-            args=(),
-            exc_info=None,
-        )
-
-        formatted = formatter.format(record)
-        assert "\033[31m" in formatted  # Red color for ERROR
-        assert "\033[0m" in formatted  # End color
-        assert "Error message" in formatted
-
-    def test_format_with_correlation_id(self):
-        """Test formatting with correlation ID."""
-        formatter = DiversifierFormatter(use_colors=False, enable_correlation_ids=True)
-
-        # Set correlation ID
-        test_corr_id = "test-correlation-id-12345"
-        correlation_id.set(test_corr_id)
-
-        try:
-            record = logging.LogRecord(
-                name="test.logger",
-                level=logging.INFO,
-                pathname="",
-                lineno=1,
-                msg="Test with correlation",
-                args=(),
-                exc_info=None,
-            )
-
-            formatted = formatter.format(record)
-            assert test_corr_id[:8] in formatted  # First 8 characters
-            assert "Test with correlation" in formatted
-        finally:
-            correlation_id.set("")
-
-    def test_format_with_exception(self):
-        """Test formatting with exception info."""
-        formatter = DiversifierFormatter(use_colors=False, enable_correlation_ids=False)
-
-        try:
-            raise ValueError("Test exception")
-        except ValueError:
-            exc_info = sys.exc_info()
-            record = logging.LogRecord(
-                name="test.logger",
-                level=logging.ERROR,
-                pathname="",
-                lineno=1,
-                msg="Error occurred",
-                args=(),
-                exc_info=exc_info,
-            )
-
-            formatted = formatter.format(record)
-            assert "Error occurred" in formatted
-            assert "ValueError: Test exception" in formatted
-            assert "Traceback" in formatted
-
-
-class TestCorrelationIdFunctions:
-    """Tests for correlation ID management functions."""
-
-    def setup_method(self):
-        """Clear correlation ID before each test."""
-        correlation_id.set("")
-
-    def test_set_correlation_id_with_value(self):
-        """Test setting a specific correlation ID."""
-        test_id = "test-123"
-        result = set_correlation_id(test_id)
-
-        assert result == test_id
-        assert get_correlation_id() == test_id
-
-    def test_set_correlation_id_auto_generate(self):
-        """Test auto-generating correlation ID."""
-        result = set_correlation_id()
-
-        assert result != ""
-        assert len(result) == 36  # UUID length
-        assert get_correlation_id() == result
-
-    def test_get_correlation_id_empty(self):
-        """Test getting correlation ID when none is set."""
-        result = get_correlation_id()
-        assert result == ""
-
-    def test_clear_correlation_id(self):
-        """Test clearing correlation ID."""
-        set_correlation_id("test-123")
-        assert get_correlation_id() == "test-123"
-
-        clear_correlation_id()
-        assert get_correlation_id() == ""
-
-    def test_correlation_id_context_isolation(self):
-        """Test that correlation IDs are isolated between contexts."""
-
-        def set_and_check_id(corr_id):
-            set_correlation_id(corr_id)
-            return get_correlation_id()
-
-        # Test in different context vars
-        ctx1 = contextvars.copy_context()
-        ctx2 = contextvars.copy_context()
-
-        result1 = ctx1.run(set_and_check_id, "context-1")
-        result2 = ctx2.run(set_and_check_id, "context-2")
-
-        assert result1 == "context-1"
-        assert result2 == "context-2"
 
 
 class TestSetupLogging:
@@ -200,38 +65,6 @@ class TestSetupLogging:
         assert isinstance(logger.handlers[0], logging.StreamHandler)
         assert logger.propagate is False
 
-    def test_setup_logging_file_only(self):
-        """Test setup logging with file handler only."""
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            log_file = f.name
-
-        try:
-            config = LoggingConfig(console=False, file_path=log_file)
-            setup_logging(config)
-
-            logger = logging.getLogger("diversifier")
-            assert len(logger.handlers) == 1
-            assert hasattr(logger.handlers[0], "stream")  # RotatingFileHandler
-            assert Path(log_file).exists()
-        finally:
-            if Path(log_file).exists():
-                Path(log_file).unlink()
-
-    def test_setup_logging_both_handlers(self):
-        """Test setup logging with both console and file handlers."""
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            log_file = f.name
-
-        try:
-            config = LoggingConfig(console=True, file_path=log_file)
-            setup_logging(config)
-
-            logger = logging.getLogger("diversifier")
-            assert len(logger.handlers) == 2
-        finally:
-            if Path(log_file).exists():
-                Path(log_file).unlink()
-
     def test_setup_logging_debug_level(self):
         """Test setup logging with DEBUG level."""
         config = LoggingConfig(level="DEBUG")
@@ -240,15 +73,16 @@ class TestSetupLogging:
         logger = logging.getLogger("diversifier")
         assert logger.level == logging.DEBUG
 
-    def test_setup_logging_no_correlation_ids(self):
-        """Test setup logging with correlation IDs disabled."""
-        config = LoggingConfig(enable_correlation_ids=False)
+    def test_setup_logging_custom_format(self):
+        """Test setup logging with custom format string."""
+        custom_format = "%(name)s - %(levelname)s - %(message)s"
+        config = LoggingConfig(format_string=custom_format)
         setup_logging(config)
 
         logger = logging.getLogger("diversifier")
         formatter = logger.handlers[0].formatter
         assert isinstance(formatter, DiversifierFormatter)
-        assert formatter.enable_correlation_ids is False
+        assert formatter._style._fmt == custom_format
 
     @patch("src.orchestration.logging_config.get_config")
     def test_setup_logging_no_config(self, mock_get_config):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -761,7 +761,7 @@ class TestLoggingConfig:
     def test_setup_logging(self):
         """Test logging setup."""
         # This is mainly to ensure no exceptions are raised
-        config = LoggingConfig(level="DEBUG", console=True)
+        config = LoggingConfig(level="DEBUG")
         setup_logging(config)
 
         logger = get_logger("test")


### PR DESCRIPTION
## Summary

Simplifies the logging configuration by removing unused CLI arguments and complex logging features as requested in issue #93.

### Changes Made

- **Removed CLI arguments**: `--log-level` and `--log-file` 
- **Kept `--verbose` flag**: Still works to set log level to DEBUG
- **Simplified LoggingConfig**: Reduced to only `level` and `format_string` fields
- **Console-only logging**: Removed file logging, rotation, and correlation ID features
- **Updated configuration template**: Simplified logging section
- **Comprehensive test updates**: Fixed all tests to match the new simplified implementation
- **Code cleanup**: Removed unused imports and dead code

### Test Plan

- [x] All existing tests updated and passing (332 tests)
- [x] CLI tests verify `--verbose` flag still works
- [x] LoggingConfig tests verify simplified structure
- [x] Configuration tests verify TOML loading works
- [x] Quality checks pass: ruff, mypy, pytest, black

### Breaking Changes

This is a breaking change for:
- Users relying on `--log-level` or `--log-file` CLI arguments
- Configuration files using removed logging fields (console, file_path, etc.)

However, since this is pre-v1.0, no backward compatibility is maintained as specified in the issue.

Closes #93

🤖 Generated with [Claude Code](https://claude.ai/code)