### PR TITLE
Fix: Remove unused MCPConfig from configuration (#106)

### DIFF
--- a/src/orchestration/config.py
+++ b/src/orchestration/config.py
@@ -18,17 +18,6 @@ class LoggingConfig:
 
 
 @dataclass
-class MCPConfig:
-    """MCP server configuration settings."""
-
-    filesystem_server_path: str = "src/mcp_servers/filesystem/server.py"
-    testing_server_path: str = "src/mcp_servers/testing/server.py"
-    git_server_path: str = "src/mcp_servers/git/server.py"
-    docker_server_path: str = "src/mcp_servers/docker/server.py"
-    timeout: int = 30
-
-
-@dataclass
 class MigrationConfig:
     """Migration workflow configuration settings."""
 
@@ -120,7 +109,6 @@ class DiversifierConfig:
 
     llm: LLMConfig  # LLM configuration (REQUIRED)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
-    mcp: MCPConfig = field(default_factory=MCPConfig)
     migration: MigrationConfig = field(default_factory=MigrationConfig)
     project_root: str = "."
     temp_dir: str = "/tmp/diversifier"
@@ -192,8 +180,6 @@ class ConfigManager:
         env_mappings = {
             # Logging configuration
             "DIVERSIFIER_LOG_LEVEL": ("logging", "level"),
-            # MCP configuration
-            "DIVERSIFIER_MCP_TIMEOUT": ("mcp", "timeout"),
             # Migration configuration
             "DIVERSIFIER_MAX_ITERATIONS": ("migration", "max_iterations"),
             "DIVERSIFIER_TEST_TIMEOUT": ("migration", "test_timeout"),
@@ -272,7 +258,6 @@ class ConfigManager:
         """
         # Extract nested configurations
         logging_data = config_data.get("logging", {})
-        mcp_data = config_data.get("mcp", {})
         migration_data = config_data.get("migration", {})
         llm_data = config_data.get("llm", {})
 
@@ -283,9 +268,6 @@ class ConfigManager:
                 for k, v in logging_data.items()
                 if k in LoggingConfig.__dataclass_fields__
             }
-        )
-        mcp_config = MCPConfig(
-            **{k: v for k, v in mcp_data.items() if k in MCPConfig.__dataclass_fields__}
         )
         migration_config = MigrationConfig(
             **{
@@ -317,13 +299,12 @@ class ConfigManager:
         top_level_data = {
             k: v
             for k, v in config_data.items()
-            if k not in ["logging", "mcp", "migration", "llm"]
+            if k not in ["logging", "migration", "llm"]
             and k in DiversifierConfig.__dataclass_fields__
         }
 
         return DiversifierConfig(
             logging=logging_config,
-            mcp=mcp_config,
             migration=migration_config,
             llm=llm_config,
             **top_level_data,
@@ -359,13 +340,6 @@ class ConfigManager:
 [logging]
 level = "INFO"
 format_string = "%(asctime)s | %(levelname)-8s | %(name)-25s | %(message)s"
-
-[mcp]
-filesystem_server_path = "src/mcp_servers/filesystem/server.py"
-testing_server_path = "src/mcp_servers/testing/server.py"
-git_server_path = "src/mcp_servers/git/server.py"
-docker_server_path = "src/mcp_servers/docker/server.py"
-timeout = 30
 
 [migration]
 max_iterations = 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,6 @@ from src.orchestration.config import (
     DiversifierConfig,
     LLMConfig,
     LoggingConfig,
-    MCPConfig,
     MigrationConfig,
     get_config,
     get_config_manager,
@@ -41,19 +40,6 @@ class TestLoggingConfig:
         )
         assert config.level == "DEBUG"
         assert config.format_string == "%(name)s - %(levelname)s - %(message)s"
-
-
-class TestMCPConfig:
-    """Tests for MCPConfig dataclass."""
-
-    def test_default_values(self):
-        """Test default configuration values."""
-        config = MCPConfig()
-        assert config.filesystem_server_path == "src/mcp_servers/filesystem/server.py"
-        assert config.testing_server_path == "src/mcp_servers/testing/server.py"
-        assert config.git_server_path == "src/mcp_servers/git/server.py"
-        assert config.docker_server_path == "src/mcp_servers/docker/server.py"
-        assert config.timeout == 30
 
 
 class TestMigrationConfig:
@@ -141,7 +127,6 @@ class TestDiversifierConfig:
         )
         config = DiversifierConfig(llm=llm_config)
         assert isinstance(config.logging, LoggingConfig)
-        assert isinstance(config.mcp, MCPConfig)
         assert isinstance(config.migration, MigrationConfig)
         assert isinstance(config.llm, LLMConfig)
         assert config.project_root == "."
@@ -215,7 +200,6 @@ api_key_env_var = "OPENAI_API_KEY"
                     config.logging.format_string
                     == "%(name)s - %(levelname)s - %(message)s"
                 )
-                assert config.mcp.timeout == 60
                 assert config.migration.max_iterations == 10
                 assert config.llm.provider == "openai"
                 assert config.llm.model_name == "gpt-4"
@@ -254,7 +238,6 @@ api_key_env_var = "TEST_API_KEY"
         env_vars = {
             "TEST_API_KEY": "test-key",
             "DIVERSIFIER_LOG_LEVEL": "ERROR",
-            "DIVERSIFIER_MCP_TIMEOUT": "120",
             "DIVERSIFIER_DEBUG": "true",
             "DIVERSIFIER_MIN_COVERAGE": "0.9",
             "DIVERSIFIER_LLM_PROVIDER": "google",
@@ -275,7 +258,6 @@ api_key_env_var = "TEST_API_KEY"
                     config = manager.load_config()
 
                     assert config.logging.level == "ERROR"
-                    assert config.mcp.timeout == 120
                     assert config.debug_mode is True
                     assert config.migration.min_test_coverage == 0.9
                     assert config.llm.provider == "google"


### PR DESCRIPTION
## Summary
- Removed unused MCPConfig class and all related infrastructure
- Simplified configuration structure by removing mcp field from DiversifierConfig  
- Eliminated unused server path fields and MCP timeout configuration
- Removed MCP-related environment variable mappings and config template section
- Updated all tests to remove MCPConfig references

## Changes Made
- **Removed MCPConfig class** from `src/orchestration/config.py`
- **Removed mcp field** from DiversifierConfig dataclass
- **Cleaned up environment mappings** for MCP-related variables
- **Simplified config template** by removing unused [mcp] section
- **Updated test suite** to remove all MCPConfig test cases

## Testing
- All 240 tests pass ✅
- Code formatting and linting checks pass ✅
- Type checking passes ✅

## Impact
This change simplifies the configuration system by removing unused components, making the codebase cleaner and easier to maintain. No functional changes to the core MCP server functionality, which uses hardcoded paths directly.

Closes #106

🤖 Generated with [Claude Code](https://claude.ai/code)